### PR TITLE
Add initial mobile layout and PWA scaffold

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,1 @@
+// Placeholder for future JavaScript functionality

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cruise Dashboard</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="header">
+    <h1>Cruise Dashboard</h1>
+    <img src="/assets/images/logo.png" alt="Cruise Logo" class="logo">
+  </header>
+  <nav class="nav-bar">
+    <button class="nav-button">Left</button>
+    <button class="nav-button">Crown Iris</button>
+    <button class="nav-button">Right</button>
+  </nav>
+  <main class="main-content">
+    <p>Main content will appear here</p>
+  </main>
+  <footer class="footer">
+    <img src="/assets/images/ship.png" alt="Ship" class="footer-image">
+  </footer>
+  <script src="app.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js');
+      });
+    }
+  </script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Cruise Dashboard",
+  "short_name": "Cruise",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/assets/images/logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,53 @@
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background-color: #ffffff;
+  color: #000000;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  background-color: #ffffff;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #000000;
+}
+
+.logo {
+  height: 40px;
+}
+
+.nav-bar {
+  display: flex;
+  justify-content: space-between;
+  background-color: #007bff;
+  padding: 10px;
+}
+
+.nav-button {
+  flex: 1;
+  margin: 0 5px;
+  padding: 10px;
+  background-color: #cccccc;
+  color: #ffffff;
+  border: none;
+  border-radius: 9999px;
+  font-size: 1rem;
+}
+
+.main-content {
+  padding: 20px;
+  background-color: #ffffff;
+}
+
+.footer-image {
+  width: 100%;
+  height: auto;
+  display: block;
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,30 @@
+const CACHE_NAME = 'cruise-dashboard-v1';
+const ASSETS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/app.js',
+  '/manifest.json',
+  '/assets/images/logo.png',
+  '/assets/images/ship.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- Build mobile-first layout with header, navigation, main content placeholder, and ship footer image
- Add styles with system font, blue nav bar, and pill buttons
- Introduce PWA files including manifest and service worker caching core assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b85e679b188323bed2bb8ff6234792