### PR TITLE
fix: correct asset paths, add Itinerary/Decks/Emergency sections with nav switching

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,1 +1,18 @@
-// Placeholder for future JavaScript functionality
+document.addEventListener('DOMContentLoaded', () => {
+  const buttons = document.querySelectorAll('.nav-button');
+  const sections = document.querySelectorAll('.section');
+
+  buttons.forEach(button => {
+    button.addEventListener('click', () => {
+      const target = button.getAttribute('data-target');
+
+      sections.forEach(section => {
+        if (section.id === target) {
+          section.classList.add('active');
+        } else {
+          section.classList.remove('active');
+        }
+      });
+    });
+  });
+});

--- a/index.html
+++ b/index.html
@@ -10,18 +10,20 @@
 <body>
   <header class="header">
     <h1>Cruise Dashboard</h1>
-    <img src="/assets/images/logo.png" alt="Cruise Logo" class="logo">
+    <img src="assets/images/logo.png" alt="Cruise Logo" class="logo">
   </header>
   <nav class="nav-bar">
-    <button class="nav-button">Left</button>
-    <button class="nav-button">Crown Iris</button>
-    <button class="nav-button">Right</button>
+    <button class="nav-button" data-target="itinerary">Itinerary</button>
+    <button class="nav-button" data-target="decks">Deck Plans</button>
+    <button class="nav-button" data-target="emergency">Emergency</button>
   </nav>
   <main class="main-content">
-    <p>Main content will appear here</p>
+    <section id="itinerary" class="section active">Itinerary will go here</section>
+    <section id="decks" class="section">Deck plans will go here</section>
+    <section id="emergency" class="section">Emergency contacts will go here</section>
   </main>
   <footer class="footer">
-    <img src="/assets/images/ship.png" alt="Ship" class="footer-image">
+    <img src="assets/images/ship.png" alt="Ship" class="footer-image">
   </footer>
   <script src="app.js"></script>
   <script>

--- a/styles.css
+++ b/styles.css
@@ -42,8 +42,16 @@ body {
 }
 
 .main-content {
-  padding: 20px;
   background-color: #ffffff;
+}
+
+.section {
+  display: none;
+  padding: 20px;
+}
+
+.section.active {
+  display: block;
 }
 
 .footer-image {

--- a/sw.js
+++ b/sw.js
@@ -1,12 +1,12 @@
-const CACHE_NAME = 'cruise-dashboard-v1';
+const CACHE_NAME = 'cruise-dashboard-v3';
 const ASSETS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/app.js',
-  '/manifest.json',
-  '/assets/images/logo.png',
-  '/assets/images/ship.png'
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './manifest.json',
+  './assets/images/logo.png',
+  './assets/images/ship.png'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- fix image paths so logo and ship load from `assets/images`
- add Itinerary, Deck Plans, and Emergency sections with nav buttons
- implement JS section switching and update service worker cache paths

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I https://osintsecrets.github.io/web/assets/images/logo.png` *(403 Forbidden)*
- `curl -I https://osintsecrets.github.io/web/assets/images/ship.png` *(403 Forbidden)*
- `npm install jsdom --no-save` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b861f543d483238c70af36b4008699