### PR TITLE
feat: implement exact mock layout (title+logo, blue pill bar, vertical itinerary, full-width ship); bump SW cache

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,18 +1,10 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const buttons = document.querySelectorAll('.nav-button');
-  const sections = document.querySelectorAll('.section');
+  const pills = document.querySelectorAll('.nav-button');
 
-  buttons.forEach(button => {
-    button.addEventListener('click', () => {
-      const target = button.getAttribute('data-target');
-
-      sections.forEach(section => {
-        if (section.id === target) {
-          section.classList.add('active');
-        } else {
-          section.classList.remove('active');
-        }
-      });
+  pills.forEach(pill => {
+    pill.addEventListener('click', (event) => {
+      event.preventDefault();
+      // TODO: implement navigation when sections are available
     });
   });
 });

--- a/index.html
+++ b/index.html
@@ -8,23 +8,46 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header class="header">
-    <h1>Cruise Dashboard</h1>
-    <img src="assets/images/logo.png" alt="Cruise Logo" class="logo">
-  </header>
-  <nav class="nav-bar">
-    <button class="nav-button" data-target="itinerary">Itinerary</button>
-    <button class="nav-button" data-target="decks">Deck Plans</button>
-    <button class="nav-button" data-target="emergency">Emergency</button>
-  </nav>
-  <main class="main-content">
-    <section id="itinerary" class="section active">Itinerary will go here</section>
-    <section id="decks" class="section">Deck plans will go here</section>
-    <section id="emergency" class="section">Emergency contacts will go here</section>
-  </main>
-  <footer class="footer">
-    <img src="assets/images/ship.png" alt="Ship" class="footer-image">
-  </footer>
+  <div class="container">
+    <header class="header">
+      <h1>CRUISE DASHBOARD</h1>
+      <img src="assets/images/logo.png" alt="Cruise Logo" class="logo">
+    </header>
+    <nav class="nav-bar">
+      <button class="nav-button">Itinerary</button>
+      <button class="nav-button">Floor plan</button>
+      <button class="nav-button">important info</button>
+      <button class="nav-button pill--disabled" aria-disabled="true"></button>
+    </nav>
+    <section id="timeline" class="timeline">
+      <ul class="timeline-list">
+        <li class="event">
+          Sun, Oct 19, 2025 — Haifa (Israel)<br>
+          Departs 13:30
+        </li>
+        <li class="arrow">↓</li>
+        <li class="duration">25 hours and 10 minutes</li>
+        <li class="event">
+          Mon, Oct 20 — Rhodes (Greece)<br>
+          Arrives 15:30
+        </li>
+        <li class="arrow">↓</li>
+        <li class="duration">10 hours and 45 minutes</li>
+        <li class="event">
+          Tue, Oct 21 — Agios Nikolaos,<br>
+          Crete (Greece)<br>
+          Arrives 12:00
+        </li>
+        <li class="arrow">↓</li>
+        <li class="duration">34 hours</li>
+        <li class="event">
+          Thu, Oct 23 — Haifa (Israel)<br>
+          Arrives 08:00.
+        </li>
+      </ul>
+    </section>
+    <img src="assets/images/ship.png" alt="Ship" class="ship-image">
+  </div>
   <script src="app.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
   "name": "Cruise Dashboard",
   "short_name": "Cruise",
-  "start_url": "/index.html",
+  "start_url": "index.html",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
   "icons": [
     {
-      "src": "/assets/images/logo.png",
+      "src": "assets/images/logo.png",
       "sizes": "192x192",
       "type": "image/png"
     }

--- a/styles.css
+++ b/styles.css
@@ -1,61 +1,101 @@
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background-color: #ffffff;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 16px;
   color: #000000;
 }
 
+.container {
+  max-width: 430px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
 .header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 16px;
-  background-color: #ffffff;
+  position: relative;
+  padding: 16px;
+  padding-right: 72px;
+  text-align: center;
 }
 
 .header h1 {
   margin: 0;
-  font-size: 1.25rem;
-  color: #000000;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #0d5bd7;
+  border-bottom: 3px solid currentColor;
+  padding-bottom: 8px;
 }
 
 .logo {
-  height: 40px;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  height: 48px;
 }
 
 .nav-bar {
   display: flex;
-  justify-content: space-between;
-  background-color: #007bff;
-  padding: 10px;
+  gap: 8px;
+  background-color: #0d5bd7;
+  padding: 8px;
+  overflow-x: auto;
 }
 
 .nav-button {
   flex: 1;
-  margin: 0 5px;
-  padding: 10px;
-  background-color: #cccccc;
+  background-color: #c9c9c9;
   color: #ffffff;
   border: none;
   border-radius: 9999px;
+  padding: 10px 14px;
   font-size: 1rem;
+  text-align: center;
+  min-height: 44px;
 }
 
-.main-content {
-  background-color: #ffffff;
+.nav-button:focus-visible {
+  outline: 2px solid #000000;
+  outline-offset: 2px;
 }
 
-.section {
-  display: none;
-  padding: 20px;
+.pill--disabled {
+  opacity: 0.5;
+  pointer-events: none;
 }
 
-.section.active {
-  display: block;
+.timeline {
+  margin-top: 24px;
 }
 
-.footer-image {
+.timeline-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  text-align: center;
+}
+
+.event {
+  line-height: 1.5;
+  margin-bottom: 24px;
+}
+
+.arrow {
+  font-size: 24px;
+  color: #0d5bd7;
+  margin-bottom: 8px;
+}
+
+.duration {
+  font-weight: 600;
+  color: #0d5bd7;
+  margin-bottom: 24px;
+}
+
+.ship-image {
   width: 100%;
   height: auto;
   display: block;
+  margin-top: 24px;
 }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'cruise-dashboard-v3';
+const CACHE_NAME = 'cruise-dashboard-v4';
 const ASSETS_TO_CACHE = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- Centered CRUISE DASHBOARD heading with top-right logo and blue nav bar of four pill buttons
- Added vertical itinerary timeline with arrows and durations plus full-width ship image footer
- Simplified JS to placeholder pill handlers and bumped service worker cache

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b86f59071c8323a0619a5c76038e3f