### PR TITLE
Enhance mobile PWA with dynamic itinerary and deck listing

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
-// Unified app script: animated drawer, refresh, Android install, helpers, SW registration
 (function () {
   const body = document.body;
   const menuBtn = document.getElementById('menuBtn');
@@ -9,107 +8,151 @@
   const a2hsToggle = document.getElementById('showA2HS');
   const a2hsHelp = document.getElementById('a2hsHelp');
   const installBtn = document.getElementById('installBtn');
+  const updateToast = document.getElementById('updateToast');
 
   let lastFocus = null;
 
-  function lockScroll(lock) { body.style.overflow = lock ? 'hidden' : ''; }
-
-  function openMenu() {
+  function lockScroll(lock){ body.style.overflow = lock ? 'hidden' : ''; }
+  function openMenu(){
     lastFocus = document.activeElement;
     sideMenu.classList.add('open');
-    overlay.hidden = false;
-    overlay.classList.add('show');
-    sideMenu.setAttribute('aria-hidden', 'false');
-    menuBtn?.setAttribute('aria-expanded', 'true');
+    overlay.hidden = false; overlay.classList.add('show');
+    sideMenu.setAttribute('aria-hidden','false');
+    menuBtn?.setAttribute('aria-expanded','true');
     menuBtn?.classList.add('active');
     lockScroll(true);
-    // focus first focusable element in menu
-    (sideMenu.querySelector('a,button,[tabindex]:not([tabindex="-1"])') || sideMenu).focus();
+    (sideMenu.querySelector('a,button,[tabindex]:not([tabindex="-1"])')||sideMenu).focus();
   }
-
-  function closeMenu() {
+  function closeMenu(){
     sideMenu.classList.remove('open');
-    overlay.classList.remove('show');
-    setTimeout(() => overlay.hidden = true, 200);
-    sideMenu.setAttribute('aria-hidden', 'true');
-    menuBtn?.setAttribute('aria-expanded', 'false');
+    overlay.classList.remove('show'); setTimeout(()=>overlay.hidden=true,200);
+    sideMenu.setAttribute('aria-hidden','true');
+    menuBtn?.setAttribute('aria-expanded','false');
     menuBtn?.classList.remove('active');
     lockScroll(false);
     lastFocus?.focus?.();
   }
-
   menuBtn?.addEventListener('click', openMenu);
   closeBtn?.addEventListener('click', closeMenu);
   overlay?.addEventListener('click', closeMenu);
-  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeMenu(); });
+  document.addEventListener('keydown',(e)=>{ if(e.key==='Escape') closeMenu(); });
 
-  // Focus trap inside sideMenu
-  sideMenu?.addEventListener('keydown', (e) => {
-    if (e.key !== 'Tab') return;
-    const focusables = sideMenu.querySelectorAll('a,button,[tabindex]:not([tabindex="-1"])');
-    if (!focusables.length) return;
-    const first = focusables[0], last = focusables[focusables.length - 1];
-    if (e.shiftKey && document.activeElement === first) { last.focus(); e.preventDefault(); }
-    else if (!e.shiftKey && document.activeElement === last) { first.focus(); e.preventDefault(); }
+  // Focus trap
+  sideMenu?.addEventListener('keydown',(e)=>{
+    if(e.key!=='Tab') return;
+    const nodes = sideMenu.querySelectorAll('a,button,[tabindex]:not([tabindex="-1"])');
+    if(!nodes.length) return;
+    const first = nodes[0], last = nodes[nodes.length-1];
+    if(e.shiftKey && document.activeElement===first){ last.focus(); e.preventDefault(); }
+    else if(!e.shiftKey && document.activeElement===last){ first.focus(); e.preventDefault(); }
   });
 
-  // Refresh: update SW then reload
-  refreshBtn?.addEventListener('click', async () => {
-    try {
+  // Refresh (check SW, apply immediately)
+  refreshBtn?.addEventListener('click', async ()=>{
+    try{
       const reg = await navigator.serviceWorker?.getRegistration();
       await reg?.update();
-      if (reg?.waiting) reg.waiting.postMessage({ type: 'SKIP_WAITING' });
-    } catch (_) { }
+      if(reg?.waiting) reg.waiting.postMessage({type:'SKIP_WAITING'});
+    }catch(_){ }
     location.reload();
   });
 
-  // Install (Android only)
-  let deferredPrompt = null;
-  const isStandalone =
-    window.matchMedia('(display-mode: standalone)').matches ||
-    window.navigator.standalone === true;
-  if (isStandalone && installBtn) installBtn.hidden = true;
+  // Update toast (notify when a new version is ready)
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.addEventListener('controllerchange', ()=>{
+      if(updateToast){ updateToast.classList.add('show'); setTimeout(()=>updateToast.classList.remove('show'), 3500); }
+    });
+  }
 
-  window.addEventListener('beforeinstallprompt', (e) => {
-    e.preventDefault();
-    deferredPrompt = e;
-    if (installBtn) installBtn.hidden = false;
+  // Platform-specific A2HS instructions
+  const iOS = /iphone|ipad|ipod/i.test(navigator.userAgent);
+  const android = /android/i.test(navigator.userAgent);
+  if(a2hsHelp){
+    a2hsHelp.innerHTML = iOS
+      ? `<ol>
+           <li>Open this site in <strong>Safari</strong> on your iPhone.</li>
+           <li>Tap the <strong>Share</strong> icon.</li>
+           <li>Choose <strong>Add to Home Screen</strong>.</li>
+           <li>Confirm to add the icon to your Home Screen.</li>
+         </ol>`
+      : `<ol>
+           <li>Open this site in <strong>Chrome</strong> on your Android phone.</li>
+           <li>Tap the <strong>⋮</strong> menu (top-right).</li>
+           <li>Choose <strong>Add to Home screen</strong> or <strong>Install app</strong>.</li>
+           <li>Confirm to add the icon to your Home Screen.</li>
+         </ol>`;
+  }
+  a2hsToggle?.addEventListener('click', ()=>{
+    if(!a2hsHelp) return;
+    const hidden = a2hsHelp.hasAttribute('hidden');
+    if(hidden) a2hsHelp.removeAttribute('hidden'); else a2hsHelp.setAttribute('hidden','');
   });
 
-  installBtn?.addEventListener('click', async () => {
-    if (!deferredPrompt) return;
+  // Android install button via beforeinstallprompt
+  let deferredPrompt=null;
+  const standalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone===true;
+  if(standalone && installBtn) installBtn.hidden=true;
+  window.addEventListener('beforeinstallprompt',(e)=>{
+    e.preventDefault(); deferredPrompt=e; if(installBtn) installBtn.hidden=false;
+  });
+  installBtn?.addEventListener('click', async ()=>{
+    if(!deferredPrompt) return;
     deferredPrompt.prompt();
-    try { await deferredPrompt.userChoice; }
-    finally {
-      installBtn.hidden = true;
-      deferredPrompt = null;
-    }
+    try{ await deferredPrompt.userChoice; } finally { installBtn.hidden=true; deferredPrompt=null; }
   });
+  window.addEventListener('appinstalled', ()=>{ if(installBtn) installBtn.hidden=true; });
 
-  window.addEventListener('appinstalled', () => { if (installBtn) installBtn.hidden = true; });
+  // ===== Dynamic renderers =====
 
-  // Toggle Android manual A2HS help
-  a2hsToggle?.addEventListener('click', () => {
-    if (!a2hsHelp) return;
-    if (a2hsHelp.hasAttribute('hidden')) a2hsHelp.removeAttribute('hidden');
-    else a2hsHelp.setAttribute('hidden', '');
-  });
-
-  // Mark active nav item based on filename
-  (function markActive() {
-    const map = {
-      'itinerary.html': 'nav-itinerary',
-      'floor-plan.html': 'nav-floor',
-      'important-info.html': 'nav-info'
-    };
-    const file = (location.pathname.split('/').pop() || 'index.html');
-    const id = map[file];
-    const el = id && document.getElementById(id);
-    if (el) el.classList.add('pill--active');
+  // Itinerary: if data/itinerary.json has items, render them
+  (async function renderItinerary(){
+    const mount = document.getElementById('itineraryDynamic');
+    if(!mount) return;
+    try{
+      const res = await fetch('data/itinerary.json', {cache:'no-store'});
+      const data = await res.json();
+      if(Array.isArray(data.items) && data.items.length){
+        const ul = document.createElement('ul');
+        ul.className = 'timeline-list';
+        data.items.forEach(row=>{
+          const li = document.createElement('li');
+          if(row.gap){
+            li.innerHTML = `<div class="gap"><span class="arrow">↓</span> ${row.gap}</div>`;
+          }else{
+            li.innerHTML = `<div class="event"><div class="when">${row.when||''}</div><div class="note">${row.note||''}</div></div>`;
+          }
+          ul.appendChild(li);
+        });
+        mount.replaceChildren(ul);
+      }
+    }catch(_){ }
   })();
+
+  // Deck plans: read data/decks.json and render cards
+  (async function renderDecks(){
+    const root = document.getElementById('decksRoot');
+    if(!root) return;
+    try{
+      const res = await fetch('data/decks.json', {cache:'no-store'});
+      const data = await res.json();
+      if(Array.isArray(data.decks) && data.decks.length){
+        root.innerHTML = '';
+        data.decks.forEach(d=>{
+          const card = document.createElement('a');
+          card.className='deck-card';
+          card.href = d.image;
+          card.target = '_blank';
+          card.rel = 'noopener';
+          card.innerHTML = `<img loading="lazy" src="${d.image}" alt="${d.name||'Deck plan'}"><div class="deck-card__label">${d.name||''}</div>`;
+          root.appendChild(card);
+        });
+      }
+    }catch(_){ }
+  })();
+
 })();
 
-// Service Worker registration (all pages)
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => navigator.serviceWorker.register('sw.js'));
+// SW registration (all pages)
+if('serviceWorker' in navigator){
+  window.addEventListener('load',()=>navigator.serviceWorker.register('sw.js'));
 }

--- a/data/decks.json
+++ b/data/decks.json
@@ -1,0 +1,7 @@
+{
+  "decks": [
+    // Example (fill later):
+    // { "name": "Deck 3 — Reception", "image": "assets/images/decks/deck-03.png" },
+    // { "name": "Deck 4 — Dining",    "image": "assets/images/decks/deck-04.png" }
+  ]
+}

--- a/data/itinerary.json
+++ b/data/itinerary.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    // Example (fill later in Haifa):
+    // {
+    //   "when": "Sun, Oct 19 — Haifa (Israel)",
+    //   "note": "Departs 13:30"
+    // },
+    // { "gap": "25 hours 10 min" },
+    // {
+    //   "when": "Mon, Oct 20 — Rhodes (Greece)",
+    //   "note": "Arrives 15:30"
+    // }
+  ]
+}

--- a/floor-plan.html
+++ b/floor-plan.html
@@ -3,6 +3,20 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Social preview -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Cruise Dashboard">
+  <meta property="og:title" content="Cruise Dashboard">
+  <meta property="og:description" content="All cruise info, schedules and contacts — offline-ready.">
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <meta property="og:url" content="https://osintsecrets.github.io/web/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cruise Dashboard">
+  <meta name="twitter:description" content="All cruise info, schedules and contacts — offline-ready.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <!-- iOS PWA niceties -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>Floor Plan • Cruise Dashboard</title>
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
@@ -47,14 +61,19 @@
     </div>
   </aside>
 
-  <main class="main-content container">
-    <p>Add deck images to assets/images/ as deck-*.png|jpg|gif. They will be displayed here in the next step.</p>
+  <main class="main-content">
+    <section class="container">
+      <h2>Deck Plans</h2>
+      <p class="muted">Upload images to <code>assets/images/decks/</code> and list them in <code>data/decks.json</code>. They will appear here automatically.</p>
+      <div id="decksRoot" class="deck-grid"></div>
+    </section>
   </main>
 
   <footer>
     <img src="assets/images/ship.png" alt="Ship" class="footer-image">
   </footer>
 
+  <div id="updateToast" role="status" aria-live="polite" aria-atomic="true">Updated! You’re on the latest version.</div>
   <script src="app.js"></script>
 </body>
 </html>

--- a/important-info.html
+++ b/important-info.html
@@ -3,6 +3,20 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Social preview -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Cruise Dashboard">
+  <meta property="og:title" content="Cruise Dashboard">
+  <meta property="og:description" content="All cruise info, schedules and contacts — offline-ready.">
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <meta property="og:url" content="https://osintsecrets.github.io/web/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cruise Dashboard">
+  <meta name="twitter:description" content="All cruise info, schedules and contacts — offline-ready.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <!-- iOS PWA niceties -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>Important Info • Cruise Dashboard</title>
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
@@ -47,62 +61,94 @@
     </div>
   </aside>
 
-  <main class="main-content container">
-    <div class="table-container">
+  <main class="main-content">
+    <section class="container">
       <h2>Important Phone Numbers</h2>
-      <table class="info-table">
-        <thead>
-          <tr>
-            <th>Category</th>
-            <th>Service / Location</th>
-            <th>Number / Address</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr><td rowspan="13"><strong>Greece — Nationwide</strong></td><td>Emergency (European-wide)</td><td>112</td></tr>
-          <tr><td>Ambulance (EKAB)</td><td>166</td></tr>
-          <tr><td>Fire Department</td><td>199</td></tr>
-          <tr><td>Police</td><td>100</td></tr>
-          <tr><td>Anti-drug Police</td><td>109</td></tr>
-          <tr><td>Coast Guard</td><td>108</td></tr>
-          <tr><td>Tourist Police (nationwide)</td><td>171</td></tr>
-          <tr><td>Pharmacies</td><td>107</td></tr>
-          <tr><td>Hospitals (directory)</td><td>106</td></tr>
-          <tr><td>Forest Fire Authority</td><td>191</td></tr>
-          <tr><td>Traffic Police (general)</td><td>10400</td></tr>
-          <tr><td>Weather Service</td><td>148</td></tr>
-          <tr><td>International Phone Assistance</td><td>139</td></tr>
-          <tr><td colspan="2">General Telephone Information</td><td>11888</td></tr>
-          <tr><td rowspan="6"><strong>Rhodes (Island)</strong></td><td>Police Emergency</td><td>100</td></tr>
-          <tr><td>Fire Service</td><td>199</td></tr>
-          <tr><td>Ambulance</td><td>166</td></tr>
-          <tr><td>Forestry Fire Service</td><td>1591</td></tr>
-          <tr><td>Tourist Police</td><td>171 or +30-22410-27423 / 23329</td></tr>
-          <tr><td>Hospital of Rhodes</td><td>+30 22413 60000</td></tr>
-          <tr><td rowspan="8"><strong>Crete (Island)</strong></td><td>Emergency (national)</td><td>112</td></tr>
-          <tr><td>Police</td><td>100</td></tr>
-          <tr><td>Fire Brigade</td><td>199</td></tr>
-          <tr><td>Ambulance</td><td>166</td></tr>
-          <tr><td>Doctors SOS</td><td>1016</td></tr>
-          <tr><td>Drug Squad</td><td>109</td></tr>
-          <tr><td>Medical Advice</td><td>197</td></tr>
-          <tr><td>OTE (Telecom service)</td><td>134</td></tr>
-          <tr><td rowspan="3"><strong>U.S. Embassy – Athens</strong></td><td>Address</td><td>91 Vasilisis Sophias Avenue, 10160 Athens, Greece</td></tr>
-          <tr><td>Main Phone</td><td>+30-210-721-2951</td></tr>
-          <tr><td>Emergency After-Hours Phone</td><td>+30-210-729-4444 or +30-210-729-4301</td></tr>
-          <tr><td><strong>U.S. Consulate – Thessaloniki</strong></td><td>Address</td><td>43 Tsimiski, 7th Floor, 54623 Thessaloniki, Greece</td></tr>
-          <tr><td rowspan="2"><strong>Israeli Embassy – Athens</strong></td><td>Address</td><td>Leoforos Marathonodromon 1 (Marathonodromou Street 1), 154 52 - Paleo Psichiko, Athens, Greece</td></tr>
-          <tr><td>Phone</td><td>+30-210-670-5500</td></tr>
-          <tr><td><strong>Chabad of Athens (Greece)</strong></td><td>Address</td><td>Aisopou 10, Athens 10554, Greece</td></tr>
-        </tbody>
-      </table>
-    </div>
+
+      <details class="acc" open>
+        <summary class="acc__summary">Greece — Nationwide</summary>
+        <ul class="acc__list">
+          <li><strong>Emergency (EU-wide):</strong> <a href="tel:112">112</a></li>
+          <li><strong>Ambulance (EKAB):</strong> <a href="tel:166">166</a></li>
+          <li><strong>Fire Department:</strong> <a href="tel:199">199</a></li>
+          <li><strong>Police:</strong> <a href="tel:100">100</a></li>
+          <li><strong>Anti-drug Police:</strong> <a href="tel:109">109</a></li>
+          <li><strong>Coast Guard:</strong> <a href="tel:108">108</a></li>
+          <li><strong>Tourist Police (nationwide):</strong> <a href="tel:171">171</a></li>
+          <li><strong>Pharmacies:</strong> <a href="tel:107">107</a></li>
+          <li><strong>Hospitals (directory):</strong> <a href="tel:106">106</a></li>
+          <li><strong>Forest Fire Authority:</strong> <a href="tel:191">191</a></li>
+          <li><strong>Traffic Police (general):</strong> <a href="tel:10400">10400</a></li>
+          <li><strong>Weather Service:</strong> <a href="tel:148">148</a></li>
+          <li><strong>International Phone Assistance:</strong> <a href="tel:139">139</a></li>
+          <li><strong>General Telephone Information:</strong> <a href="tel:11888">11888</a></li>
+        </ul>
+      </details>
+
+      <details class="acc">
+        <summary class="acc__summary">Rhodes (Island)</summary>
+        <ul class="acc__list">
+          <li><strong>Police Emergency:</strong> <a href="tel:100">100</a></li>
+          <li><strong>Fire Service:</strong> <a href="tel:199">199</a></li>
+          <li><strong>Ambulance:</strong> <a href="tel:166">166</a></li>
+          <li><strong>Forestry Fire Service:</strong> <a href="tel:1591">1591</a></li>
+          <li><strong>Tourist Police:</strong> <a href="tel:+302241027423">+30 22410 27423</a> / <a href="tel:+302241023329">23329</a> or <a href="tel:171">171</a></li>
+          <li><strong>Hospital of Rhodes:</strong> <a href="tel:+302241360000">+30 22413 60000</a></li>
+        </ul>
+      </details>
+
+      <details class="acc">
+        <summary class="acc__summary">Crete (Island)</summary>
+        <ul class="acc__list">
+          <li><strong>Emergency (national):</strong> <a href="tel:112">112</a></li>
+          <li><strong>Police:</strong> <a href="tel:100">100</a></li>
+          <li><strong>Fire Brigade:</strong> <a href="tel:199">199</a></li>
+          <li><strong>Ambulance:</strong> <a href="tel:166">166</a></li>
+          <li><strong>Doctors SOS:</strong> <a href="tel:1016">1016</a></li>
+          <li><strong>Drug Squad:</strong> <a href="tel:109">109</a></li>
+          <li><strong>Medical Advice:</strong> <a href="tel:197">197</a></li>
+          <li><strong>OTE (Telecom):</strong> <a href="tel:134">134</a></li>
+        </ul>
+      </details>
+
+      <details class="acc">
+        <summary class="acc__summary">U.S. Embassy – Athens</summary>
+        <ul class="acc__list">
+          <li><strong>Address:</strong> 91 Vasilisis Sophias Ave, 10160 Athens, Greece</li>
+          <li><strong>Main:</strong> <a href="tel:+302107212951">+30 210 721 2951</a></li>
+          <li><strong>Emergency After-Hours:</strong> <a href="tel:+302107294444">+30 210 729 4444</a> / <a href="tel:+302107294301">+30 210 729 4301</a></li>
+        </ul>
+      </details>
+
+      <details class="acc">
+        <summary class="acc__summary">U.S. Consulate – Thessaloniki</summary>
+        <ul class="acc__list">
+          <li><strong>Address:</strong> 43 Tsimiski, 7th Floor, 54623 Thessaloniki, Greece</li>
+        </ul>
+      </details>
+
+      <details class="acc">
+        <summary class="acc__summary">Israeli Embassy – Athens</summary>
+        <ul class="acc__list">
+          <li><strong>Address:</strong> Leof. Marathonodromon 1, 154 52 Paleo Psichiko, Athens, Greece</li>
+          <li><strong>Phone:</strong> <a href="tel:+302106705500">+30 210 670 5500</a></li>
+        </ul>
+      </details>
+
+      <details class="acc">
+        <summary class="acc__summary">Chabad of Athens (Greece)</summary>
+        <ul class="acc__list">
+          <li><strong>Address:</strong> Aisopou 10, Athens 10554, Greece</li>
+        </ul>
+      </details>
+    </section>
   </main>
 
   <footer>
     <img src="assets/images/ship.png" alt="Ship" class="footer-image">
   </footer>
 
+  <div id="updateToast" role="status" aria-live="polite" aria-atomic="true">Updated! You’re on the latest version.</div>
   <script src="app.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,21 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Social preview -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Cruise Dashboard">
+  <meta property="og:title" content="Cruise Dashboard">
+  <meta property="og:description" content="All cruise info, schedules and contacts — offline-ready.">
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <meta property="og:url" content="https://osintsecrets.github.io/web/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cruise Dashboard">
+  <meta name="twitter:description" content="All cruise info, schedules and contacts — offline-ready.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <!-- iOS PWA niceties -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>Cruise Dashboard</title>
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
@@ -85,6 +99,7 @@
     <img src="assets/images/ship.png" alt="Ship" class="footer-image">
   </footer>
 
+  <div id="updateToast" role="status" aria-live="polite" aria-atomic="true">Updated! You’re on the latest version.</div>
   <script src="app.js"></script>
 </body>
 </html>

--- a/itinerary.html
+++ b/itinerary.html
@@ -3,6 +3,20 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Social preview -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Cruise Dashboard">
+  <meta property="og:title" content="Cruise Dashboard">
+  <meta property="og:description" content="All cruise info, schedules and contacts — offline-ready.">
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <meta property="og:url" content="https://osintsecrets.github.io/web/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cruise Dashboard">
+  <meta name="twitter:description" content="All cruise info, schedules and contacts — offline-ready.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <!-- iOS PWA niceties -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>Itinerary • Cruise Dashboard</title>
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
@@ -47,33 +61,20 @@
     </div>
   </aside>
 
-  <main class="main-content container">
-    <section id="timeline" class="timeline">
-      <ul class="timeline-list">
-        <li class="event">
-          Sun, Oct 19, 2025 — Haifa (Israel)<br>
-          Departs 13:30
-        </li>
-        <li class="arrow">↓</li>
-        <li class="duration">25 hours and 10 minutes</li>
-        <li class="event">
-          Mon, Oct 20 — Rhodes (Greece)<br>
-          Arrives 15:30
-        </li>
-        <li class="arrow">↓</li>
-        <li class="duration">10 hours and 45 minutes</li>
-        <li class="event">
-          Tue, Oct 21 — Agios Nikolaos,<br>
-          Crete (Greece)<br>
-          Arrives 12:00
-        </li>
-        <li class="arrow">↓</li>
-        <li class="duration">34 hours</li>
-        <li class="event">
-          Thu, Oct 23 — Haifa (Israel)<br>
-          Arrives 08:00.
-        </li>
-      </ul>
+  <main class="main-content">
+    <section id="itineraryRoot" class="container">
+      <h2>Itinerary & Ship Schedule</h2>
+      <p class="lead">
+        Once we are on the boat and we know meal times, events and other schedules, I’ll add them here.
+        This will be done right after check-in as soon as we have the information.
+      </p>
+      <p class="lead">
+        <strong>Important:</strong> Before leaving the Port of Haifa, open the menu and tap <em>Refresh</em>
+        so the latest info is saved to your phone. Then you’ll have it offline during the trip.
+      </p>
+
+      <!-- If data/itinerary.json has items, app.js will render the schedule below: -->
+      <div id="itineraryDynamic"></div>
     </section>
   </main>
 
@@ -81,6 +82,7 @@
     <img src="assets/images/ship.png" alt="Ship" class="footer-image">
   </footer>
 
+  <div id="updateToast" role="status" aria-live="polite" aria-atomic="true">Updated! You’re on the latest version.</div>
   <script src="app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -197,3 +197,35 @@ body {
 }
 .info-table th { background:var(--blue); color:#fff }
 .info-table tr:nth-child(even) { background:#f9f9f9 }
+
+/* Mobile-friendly base */
+body{ font-size:18px; }
+.lead{ margin:8px 0 12px; line-height:1.5; }
+.muted{ color:var(--muted); }
+
+/* Timeline tidy-up */
+.timeline-list{ list-style:none; padding:0; margin:0; }
+.timeline-list li{ padding:10px 0; border-bottom:1px solid #eee; }
+.timeline-list .event .when{ font-weight:600; }
+.timeline-list .gap{ color:var(--blue); font-weight:600; }
+
+/* Accordion (important info) */
+.acc{ border:1px solid #ececec; border-radius:10px; padding:0; margin:10px 0; background:#fff; }
+.acc__summary{ list-style:none; padding:14px 16px; margin:0; font-weight:700; cursor:pointer; }
+.acc__summary::-webkit-details-marker{ display:none; }
+.acc[open] .acc__summary{ border-bottom:1px solid #ececec; }
+.acc__list{ margin:0; padding:10px 16px; }
+.acc__list li{ padding:8px 0; }
+.acc__list a{ color:var(--blue); text-decoration:none; }
+
+/* Deck grid */
+.deck-grid{ display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-top:10px; }
+.deck-card{ display:block; border:1px solid #ececec; border-radius:12px; overflow:hidden; text-decoration:none; }
+.deck-card img{ width:100%; height:auto; display:block; }
+.deck-card__label{ padding:8px 10px; font-weight:600; color:#111; }
+
+/* Update toast */
+#updateToast{ position:fixed; left:50%; transform:translateX(-50%); bottom:16px; background:#111; color:#fff; padding:10px 14px; border-radius:9999px; opacity:0; transition:opacity .25s ease; z-index:1000; }
+#updateToast.show{ opacity:1; }
+
+/* Touch target sizing for menu links/actions already handled by pill/menu-action styles */


### PR DESCRIPTION
## Summary
- add social preview, iOS tweaks, update-toast container across pages
- replace itinerary/floor plan/important info sections with dynamic placeholders and accordion layouts
- integrate JSON-driven itinerary and deck rendering with service worker v13 cache

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99cd9a58c83239230b2125d80421b