### PR TITLE
Add PWA icons and social preview metadata

### DIFF
--- a/floor-plan.html
+++ b/floor-plan.html
@@ -2,6 +2,23 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <!-- App icons -->
+  <link rel="icon" type="image/png" sizes="192x192" href="assets/images/icon-192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="assets/images/icon-512.png">
+  <link rel="apple-touch-icon" href="assets/images/icon-192.png">
+
+  <!-- Social media preview (Open Graph & Twitter Cards) -->
+  <meta property="og:title" content="Cruise Dashboard">
+  <meta property="og:description" content="Your offline-ready cruise dashboard with itinerary, deck plans, and important info.">
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://osintsecrets.github.io/web/">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cruise Dashboard">
+  <meta name="twitter:description" content="Your offline-ready cruise dashboard with itinerary, deck plans, and important info.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Social preview -->
   <meta property="og:type" content="website">
@@ -17,7 +34,7 @@
   <!-- iOS PWA niceties -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <title>Floor Plan • Cruise Dashboard</title>
+  <title>Cruise Dashboard – Floor Plan</title>
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
   <link rel="stylesheet" href="styles.css">

--- a/important-info.html
+++ b/important-info.html
@@ -2,6 +2,23 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <!-- App icons -->
+  <link rel="icon" type="image/png" sizes="192x192" href="assets/images/icon-192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="assets/images/icon-512.png">
+  <link rel="apple-touch-icon" href="assets/images/icon-192.png">
+
+  <!-- Social media preview (Open Graph & Twitter Cards) -->
+  <meta property="og:title" content="Cruise Dashboard">
+  <meta property="og:description" content="Your offline-ready cruise dashboard with itinerary, deck plans, and important info.">
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://osintsecrets.github.io/web/">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cruise Dashboard">
+  <meta name="twitter:description" content="Your offline-ready cruise dashboard with itinerary, deck plans, and important info.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Social preview -->
   <meta property="og:type" content="website">
@@ -17,7 +34,7 @@
   <!-- iOS PWA niceties -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <title>Important Info • Cruise Dashboard</title>
+  <title>Cruise Dashboard – Important Info</title>
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
   <link rel="stylesheet" href="styles.css">

--- a/index.html
+++ b/index.html
@@ -2,6 +2,23 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <!-- App icons -->
+  <link rel="icon" type="image/png" sizes="192x192" href="assets/images/icon-192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="assets/images/icon-512.png">
+  <link rel="apple-touch-icon" href="assets/images/icon-192.png">
+
+  <!-- Social media preview (Open Graph & Twitter Cards) -->
+  <meta property="og:title" content="Cruise Dashboard">
+  <meta property="og:description" content="Your offline-ready cruise dashboard with itinerary, deck plans, and important info.">
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://osintsecrets.github.io/web/">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cruise Dashboard">
+  <meta name="twitter:description" content="Your offline-ready cruise dashboard with itinerary, deck plans, and important info.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Social preview -->
   <meta property="og:type" content="website">

--- a/itinerary.html
+++ b/itinerary.html
@@ -2,6 +2,23 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <!-- App icons -->
+  <link rel="icon" type="image/png" sizes="192x192" href="assets/images/icon-192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="assets/images/icon-512.png">
+  <link rel="apple-touch-icon" href="assets/images/icon-192.png">
+
+  <!-- Social media preview (Open Graph & Twitter Cards) -->
+  <meta property="og:title" content="Cruise Dashboard">
+  <meta property="og:description" content="Your offline-ready cruise dashboard with itinerary, deck plans, and important info.">
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://osintsecrets.github.io/web/">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cruise Dashboard">
+  <meta name="twitter:description" content="Your offline-ready cruise dashboard with itinerary, deck plans, and important info.">
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png">
+
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Social preview -->
   <meta property="og:type" content="website">
@@ -17,7 +34,7 @@
   <!-- iOS PWA niceties -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <title>Itinerary • Cruise Dashboard</title>
+  <title>Cruise Dashboard – Itinerary</title>
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
   <link rel="stylesheet" href="styles.css">

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,21 @@
   "background_color": "#ffffff",
   "theme_color": "#0d5bd7",
   "icons": [
-    {"src":"assets/images/icons/icon-192.png","sizes":"192x192","type":"image/png","purpose":"any maskable"},
-    {"src":"assets/images/icons/icon-512.png","sizes":"512x512","type":"image/png","purpose":"any maskable"}
+    {
+      "src": "assets/images/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/images/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/images/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- specify PWA icons in `manifest.json`
- include app icons and social media preview tags in all pages
- standardize page titles for itinerary, floor plan, and important info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a017d0f88323b6b2869b27ae4a37