### PR TITLE
Add auto-loading floor plan deck grid with placeholders

### DIFF
--- a/app.js
+++ b/app.js
@@ -150,6 +150,70 @@
     }catch(_){ }
   })();
 
+  /* ===== Floor plans placeholder/auto loader ===== */
+  (function renderDeckGrid(){
+    const grid = document.getElementById('decksGrid');
+    if(!grid) return;
+
+    // Configure the decks you want to show as cards (titles only; images optional)
+    const DECKS = [
+      'Deck 03', 'Deck 04', 'Deck 05', 'Deck 06',
+      'Deck 07', 'Deck 08', 'Deck 09', 'Deck 10', 'Deck 11'
+    ];
+
+    // Helper to check if an image exists
+    function imageExists(src){
+      return new Promise(resolve=>{
+        const img = new Image();
+        img.onload = ()=> resolve(true);
+        img.onerror = ()=> resolve(false);
+        img.src = src;
+      });
+    }
+
+    // Build all cards
+    (async () => {
+      for (const name of DECKS){
+        const path = `assets/images/${name}.png`;     // e.g., assets/images/Deck 03.png
+
+        // shell
+        const card = document.createElement('a');
+        card.className = 'deck-card skeleton';  // start skeleton state
+        card.href = 'javascript:void(0)';
+        card.setAttribute('aria-label', `${name} deck plan`);
+
+        const header = document.createElement('div');
+        header.className = 'deck-card__header';
+        header.textContent = `${name}`;
+
+        const media = document.createElement('div');
+        media.className = 'deck-card__media';
+
+        const img = document.createElement('img');
+        img.className = 'deck-card__img';
+        img.alt = `${name} plan`;
+
+        media.appendChild(img);
+        card.appendChild(header);
+        card.appendChild(media);
+        grid.appendChild(card);
+
+        // check file
+        const exists = await imageExists(path);
+        if (exists){
+          img.src = path;
+          card.classList.remove('skeleton');
+          card.href = path;
+          card.target = '_blank';
+          card.rel = 'noopener';
+        } else {
+          // leave skeleton, keep card non-clickable
+          img.remove(); // keep the shimmering block instead of a broken image icon
+        }
+      }
+    })();
+  })();
+
 })();
 
 // SW registration (all pages)

--- a/floor-plan.html
+++ b/floor-plan.html
@@ -80,9 +80,12 @@
 
   <main class="main-content">
     <section class="container">
-      <h2>Deck Plans</h2>
-      <p class="muted">Upload images to <code>assets/images/decks/</code> and list them in <code>data/decks.json</code>. They will appear here automatically.</p>
-      <div id="decksRoot" class="deck-grid"></div>
+      <h2>Deck layouts</h2>
+      <p class="muted">These will auto-populate as soon as the deck images are uploaded to <code>assets/images/</code> named exactly <em>Deck 03.png</em>, <em>Deck 04.png</em>, …</p>
+
+      <div id="decksGrid" class="deck-grid">
+        <!-- Cards are injected by app.js -->
+      </div>
     </section>
   </main>
 

--- a/styles.css
+++ b/styles.css
@@ -229,3 +229,29 @@ body{ font-size:18px; }
 #updateToast.show{ opacity:1; }
 
 /* Touch target sizing for menu links/actions already handled by pill/menu-action styles */
+/* Deck grid (floor plans) */
+.deck-grid{ display:grid; grid-template-columns:1fr; gap:12px; margin-top:12px; }
+@media (min-width: 520px){ .deck-grid{ grid-template-columns:1fr 1fr; } }
+
+.deck-card{
+  display:block; border:1px solid #e6e6e6; border-radius:12px; background:#fff;
+  text-decoration:none; overflow:hidden; box-shadow:0 1px 4px rgba(0,0,0,.04);
+}
+.deck-card__header{
+  padding:12px 14px; background:#0d5bd7; color:#fff; font-weight:700; font-size:16px;
+}
+.deck-card__media{ position:relative; padding:12px; background:#fafafa; }
+.deck-card__img{
+  width:100%; height:auto; display:block; border-radius:8px; background:#f0f2f5;
+}
+
+/* skeleton when image missing */
+.deck-card.skeleton .deck-card__media{
+  background:linear-gradient(90deg,#f4f4f4 25%,#ececec 37%,#f4f4f4 63%);
+  background-size:400% 100%; animation:deckShimmer 1.2s ease-in-out infinite;
+  height:110px;
+}
+@keyframes deckShimmer{
+  0%{ background-position:100% 0 }
+  100%{ background-position:0 0 }
+}


### PR DESCRIPTION
## Summary
- Replace floor-plan page content with a deck layout grid container
- Add responsive deck-grid and skeleton placeholder styles
- Auto-render deck cards with image checks and fallbacks in app.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a33e448c8323a1120fafea22354b