### PR TITLE
Add Open Graph and Twitter meta tags

### DIFF
--- a/floor-plan.html
+++ b/floor-plan.html
@@ -35,6 +35,19 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>Cruise Dashboard – Floor Plan</title>
+  <!-- Open Graph for social sharing -->
+  <meta property="og:title" content="Cruise Dashboard" />
+  <meta property="og:description" content="Your offline-ready cruise companion — itinerary, deck plans, and important info at your fingertips." />
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png" />
+  <meta property="og:url" content="https://osintsecrets.github.io/web/" />
+  <meta property="og:type" content="website" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Cruise Dashboard" />
+  <meta name="twitter:description" content="Your offline-ready cruise companion — itinerary, deck plans, and important info at your fingertips." />
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png" />
+
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
   <link rel="stylesheet" href="styles.css">

--- a/important-info.html
+++ b/important-info.html
@@ -35,6 +35,19 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>Cruise Dashboard – Important Info</title>
+  <!-- Open Graph for social sharing -->
+  <meta property="og:title" content="Cruise Dashboard" />
+  <meta property="og:description" content="Your offline-ready cruise companion — itinerary, deck plans, and important info at your fingertips." />
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png" />
+  <meta property="og:url" content="https://osintsecrets.github.io/web/" />
+  <meta property="og:type" content="website" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Cruise Dashboard" />
+  <meta name="twitter:description" content="Your offline-ready cruise companion — itinerary, deck plans, and important info at your fingertips." />
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png" />
+
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
   <link rel="stylesheet" href="styles.css">

--- a/index.html
+++ b/index.html
@@ -35,6 +35,19 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>Cruise Dashboard</title>
+  <!-- Open Graph for social sharing -->
+  <meta property="og:title" content="Cruise Dashboard" />
+  <meta property="og:description" content="Your offline-ready cruise companion — itinerary, deck plans, and important info at your fingertips." />
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png" />
+  <meta property="og:url" content="https://osintsecrets.github.io/web/" />
+  <meta property="og:type" content="website" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Cruise Dashboard" />
+  <meta name="twitter:description" content="Your offline-ready cruise companion — itinerary, deck plans, and important info at your fingertips." />
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png" />
+
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
   <link rel="stylesheet" href="styles.css">

--- a/itinerary.html
+++ b/itinerary.html
@@ -35,6 +35,19 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>Cruise Dashboard – Itinerary</title>
+  <!-- Open Graph for social sharing -->
+  <meta property="og:title" content="Cruise Dashboard" />
+  <meta property="og:description" content="Your offline-ready cruise companion — itinerary, deck plans, and important info at your fingertips." />
+  <meta property="og:image" content="https://osintsecrets.github.io/web/assets/images/logo.png" />
+  <meta property="og:url" content="https://osintsecrets.github.io/web/" />
+  <meta property="og:type" content="website" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Cruise Dashboard" />
+  <meta name="twitter:description" content="Your offline-ready cruise companion — itinerary, deck plans, and important info at your fingertips." />
+  <meta name="twitter:image" content="https://osintsecrets.github.io/web/assets/images/logo.png" />
+
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0d5bd7">
   <link rel="stylesheet" href="styles.css">


### PR DESCRIPTION
## Summary
- ensure link previews show Cruise Dashboard logo and description by adding Open Graph and Twitter meta tags after the title on each page

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a351f74c8323bf156953a8180729