### PR TITLE
feat: render bilingual dynamic itinerary

### DIFF
--- a/data/itinerary.json
+++ b/data/itinerary.json
@@ -1,14 +1,32 @@
 {
   "items": [
-    // Example (fill later in Haifa):
-    // {
-    //   "when": "Sun, Oct 19 — Haifa (Israel)",
-    //   "note": "Departs 13:30"
-    // },
-    // { "gap": "25 hours 10 min" },
-    // {
-    //   "when": "Mon, Oct 20 — Rhodes (Greece)",
-    //   "note": "Arrives 15:30"
-    // }
+    {
+      "when_en": "Sun, Oct 19, 2025 — Haifa (Israel)",
+      "when_he": "יום א׳, 19 באוקטובר 2025 — חיפה (ישראל)",
+      "note_en": "Departs 13:30",
+      "note_he": "יציאה 13:30"
+    },
+    { "gap_en": "25 hours and 10 minutes", "gap_he": "25 שעות ו-10 דקות" },
+    {
+      "when_en": "Mon, Oct 20 — Rhodes (Greece)",
+      "when_he": "יום ב׳, 20 באוקטובר — רודוס (יוון)",
+      "note_en": "Arrives 15:30",
+      "note_he": "הגעה 15:30"
+    },
+    { "gap_en": "10 hours and 45 minutes", "gap_he": "10 שעות ו-45 דקות" },
+    {
+      "when_en": "Tue, Oct 21 — Agios Nikolaos, Crete (Greece)",
+      "when_he": "יום ג׳, 21 באוקטובר — אגיוס ניקולאוס, כרתים (יוון)",
+      "note_en": "Arrives 12:00",
+      "note_he": "הגעה 12:00"
+    },
+    { "gap_en": "34 hours", "gap_he": "34 שעות" },
+    {
+      "when_en": "Thu, Oct 23 — Haifa (Israel)",
+      "when_he": "יום ה׳, 23 באוקטובר — חיפה (ישראל)",
+      "note_en": "Arrives 08:00",
+      "note_he": "הגעה 08:00"
+    }
   ]
 }
+

--- a/index.html
+++ b/index.html
@@ -94,33 +94,8 @@
 
   <main class="main-content container">
     <h2 data-i18n="home.h2">Cruise Dashboard</h2>
-    <section id="timeline" class="timeline">
-      <ul class="timeline-list">
-        <li class="event">
-          Sun, Oct 19, 2025 — Haifa (Israel)<br>
-          Departs 13:30
-        </li>
-        <li class="arrow">↓</li>
-        <li class="duration">25 hours and 10 minutes</li>
-        <li class="event">
-          Mon, Oct 20 — Rhodes (Greece)<br>
-          Arrives 15:30
-        </li>
-        <li class="arrow">↓</li>
-        <li class="duration">10 hours and 45 minutes</li>
-        <li class="event">
-          Tue, Oct 21 — Agios Nikolaos,<br>
-          Crete (Greece)<br>
-          Arrives 12:00
-        </li>
-        <li class="arrow">↓</li>
-        <li class="duration">34 hours</li>
-        <li class="event">
-          Thu, Oct 23 — Haifa (Israel)<br>
-          Arrives 08:00.
-        </li>
-      </ul>
-    </section>
+    <!-- Dynamic itinerary (also shown on itinerary.html) -->
+    <div id="itineraryDynamic" class="container"></div>
     <p class="haifa-reminder" data-i18n="home.tip">Tip: Before you leave the Port of Haifa, add this site to your Home screen so you can access it offline. Whenever you have internet, open the menu and tap Refresh to get updates.</p>
   </main>
 

--- a/itinerary.html
+++ b/itinerary.html
@@ -98,10 +98,10 @@
       <p class="lead" data-i18n="it.p1">Once we are on the boat and we know meal times, events and other schedules, I’ll add them here.</p>
       <p class="lead" data-i18n="it.p2">This will be done right after check-in as soon as we have the information.</p>
       <p class="lead" data-i18n="it.p3">Important: Before leaving the Port of Haifa, open the menu and tap Refresh so the latest info is saved to your phone for offline use.</p>
-
-      <!-- If data/itinerary.json has items, app.js will render the schedule below: -->
-      <div id="itineraryDynamic"></div>
     </section>
+
+    <!-- Dynamic itinerary (also shown on index.html) -->
+    <div id="itineraryDynamic" class="container"></div>
   </main>
 
   <footer>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'cruise-dashboard-v15';
+const CACHE_NAME = 'cruise-dashboard-v16';
 
 self.addEventListener('message', (event) => {
   if (event.data?.type === 'SKIP_WAITING') self.skipWaiting();


### PR DESCRIPTION
## Summary
- render itinerary from JSON with full English/Hebrew support
- expose language state and re-render schedule when toggled
- precache new JSON and remove static itinerary markup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b3855e508323b6e0399054a220ec