### PR TITLE
feat(floor): horizontal thumbs + vertical viewer; use space filenames; bump SW

### DIFF
--- a/assets/images/MASTER_IMAGE_LIST.md
+++ b/assets/images/MASTER_IMAGE_LIST.md
@@ -1,0 +1,9 @@
+- deck 03.png
+- deck 04.png
+- deck 05.png
+- deck 06.png
+- deck 07.png
+- deck 08.png
+- deck 09.png
+- deck 10.png
+- deck 11.png

--- a/data/decks.json
+++ b/data/decks.json
@@ -1,7 +1,11 @@
-{
-  "decks": [
-    // Example (fill later):
-    // { "name": "Deck 3 — Reception", "image": "assets/images/decks/deck-03.png" },
-    // { "name": "Deck 4 — Dining",    "image": "assets/images/decks/deck-04.png" }
-  ]
-}
+[
+  {"id":"03","image":"assets/images/deck 03.png","label":{"en":"Deck 03","he":"סיפון 03"}},
+  {"id":"04","image":"assets/images/deck 04.png","label":{"en":"Deck 04","he":"סיפון 04"}},
+  {"id":"05","image":"assets/images/deck 05.png","label":{"en":"Deck 05","he":"סיפון 05"}},
+  {"id":"06","image":"assets/images/deck 06.png","label":{"en":"Deck 06","he":"סיפון 06"}},
+  {"id":"07","image":"assets/images/deck 07.png","label":{"en":"Deck 07","he":"סיפון 07"}},
+  {"id":"08","image":"assets/images/deck 08.png","label":{"en":"Deck 08","he":"סיפון 08"}},
+  {"id":"09","image":"assets/images/deck 09.png","label":{"en":"Deck 09","he":"סיפון 09"}},
+  {"id":"10","image":"assets/images/deck 10.png","label":{"en":"Deck 10","he":"סיפון 10"}},
+  {"id":"11","image":"assets/images/deck 11.png","label":{"en":"Deck 11","he":"סיפון 11"}}
+]

--- a/floor-plan.html
+++ b/floor-plan.html
@@ -94,14 +94,25 @@
 
   <main class="main-content">
     <section class="container">
-      <h2 data-i18n="decks.h2">Deck layouts</h2>
-      <p class="muted" data-i18n="decks.p">These will auto-populate as soon as the deck images are uploaded to assets/images/ named exactly Deck 03.png, Deck 04.png, …</p>
+      <h2 data-i18n="floor_title">Floor plan</h2>
+      <p class="muted" data-i18n="floor_subtitle">Tap a deck to view the map. Images will appear when available.</p>
 
-      <div id="decksGrid" class="deck-grid">
-        <!-- Cards are injected by app.js -->
+      <div id="deckGrid" class="deck-grid">
+        <!-- Cards are injected by floor.js -->
       </div>
     </section>
   </main>
+
+  <dialog id="deckViewer" class="deck-viewer">
+    <div class="viewer-stage">
+      <img id="deckImage" alt="">
+    </div>
+    <div class="viewer-meta">
+      <div id="deckViewerTitle"></div>
+      <p id="zoomHint"></p>
+      <button id="closeViewer" type="button" data-i18n="close">Close</button>
+    </div>
+  </dialog>
 
   <footer>
     <img src="assets/images/ship.png" alt="Ship" class="footer-image">
@@ -109,5 +120,6 @@
 
   <div id="updateToast" role="status" aria-live="polite" aria-atomic="true" data-i18n="toast.updated">Updated! You’re on the latest version.</div>
   <script src="app.js"></script>
+  <script src="floor.js"></script>
 </body>
 </html>

--- a/floor.js
+++ b/floor.js
@@ -1,0 +1,126 @@
+/* floor.js — deck grid + full-screen viewer (EN/HE), filenames with spaces supported */
+(function () {
+  const lang = (localStorage.getItem('lang') || 'en').toLowerCase() === 'he' ? 'he' : 'en';
+  const T = {
+    en: {
+      floor_title: 'Floor plan',
+      floor_subtitle: 'Tap a deck to view the map. Images will appear when available.',
+      open: 'Open',
+      close: 'Close',
+      no_image: 'Image coming soon',
+      zoom_hint: 'Pinch to zoom. Drag to pan.',
+      deck: 'Deck'
+    },
+    he: {
+      floor_title: 'תוכנית סיפונים',
+      floor_subtitle: 'הקישו על סיפון להצגת המפה. התמונות יופיעו כאשר יהיו זמינות.',
+      open: 'פתח',
+      close: 'סגור',
+      no_image: 'התמונה תעלה בקרוב',
+      zoom_hint: 'צמצמו/הגדילו עם האצבעות וגררו להזזה.',
+      deck: 'סיפון'
+    }
+  }[lang];
+
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    if (T[key]) el.textContent = T[key];
+  });
+
+  const grid = document.getElementById('deckGrid');
+  if (!grid) return;
+
+  // Viewer elements
+  const viewer = document.getElementById('deckViewer');
+  const viewerTitle = document.getElementById('deckViewerTitle');
+  const viewerImg = document.getElementById('deckImage');
+  const closeBtn = document.getElementById('closeViewer');
+
+  const openViewer = (deck) => {
+    viewerTitle.textContent = (deck.label && deck.label[lang]) ? deck.label[lang] : `${T.deck} ${deck.id}`;
+    viewerImg.alt = viewerTitle.textContent;
+    viewerImg.src = encodeURI(deck.image); // handles spaces
+    viewerImg.onerror = () => {
+      viewerImg.onerror = null;
+      const svg = encodeURIComponent(`
+        <svg xmlns='http://www.w3.org/2000/svg' width='1400' height='1800'>
+          <rect width='100%' height='100%' fill='#f2f2f2'/>
+          <g font-family='system-ui,-apple-system,Segoe UI,Roboto' fill='#888' text-anchor='middle'>
+            <text x='50%' y='45%' font-size='56'>${T.no_image}</text>
+            <text x='50%' y='60%' font-size='28'>assets/images/deck ${deck.id}.png</text>
+          </g>
+        </svg>`);
+      viewerImg.src = `data:image/svg+xml;charset=utf-8,${svg}`;
+    };
+    if (typeof viewer.showModal === 'function') viewer.showModal();
+    else viewer.setAttribute('open','');
+    document.body.style.overflow = 'hidden';
+  };
+
+  const closeViewer = () => {
+    if (typeof viewer.close === 'function') viewer.close();
+    else viewer.removeAttribute('open');
+    document.body.style.overflow = '';
+    viewerImg.src = '';
+  };
+
+  closeBtn.addEventListener('click', closeViewer);
+  viewer.addEventListener('click', (e) => {
+    const rect = viewerImg.getBoundingClientRect();
+    if (e.clientX < rect.left || e.clientX > rect.right || e.clientY < rect.top || e.clientY > rect.bottom) {
+      closeViewer();
+    }
+  });
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeViewer(); });
+
+  function cardTemplate(deck) {
+    const title = (deck.label && deck.label[lang]) ? deck.label[lang] : `${T.deck} ${deck.id}`;
+    const card = document.createElement('button');
+    card.className = 'deck-card';
+    card.type = 'button';
+    card.setAttribute('aria-label', `${title} – ${T.open}`);
+    card.innerHTML = `
+      <div class="deck-thumb">
+        <img loading="lazy" alt="${title}">
+      </div>
+      <div class="deck-meta">
+        <div class="deck-title">${title}</div>
+        <div class="deck-action">${T.open}</div>
+      </div>
+    `;
+    const img = card.querySelector('img');
+    img.src = encodeURI(deck.image); // horizontal thumb
+    img.onerror = () => {
+      img.onerror = null;
+      const svg = encodeURIComponent(`
+        <svg xmlns='http://www.w3.org/2000/svg' width='800' height='500'>
+          <rect width='100%' height='100%' fill='#fafafa'/>
+          <g font-family='system-ui,-apple-system,Segoe UI,Roboto' fill='#bbb' text-anchor='middle'>
+            <text x='50%' y='52%' font-size='40'>${T.no_image}</text>
+          </g>
+        </svg>`);
+      img.src = `data:image/svg+xml;charset=utf-8,${svg}`;
+    };
+    card.addEventListener('click', () => openViewer(deck));
+    return card;
+  }
+
+  fetch('data/decks.json')
+    .then(r => r.json())
+    .then(decks => {
+      decks.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
+      decks.forEach(deck => grid.appendChild(cardTemplate(deck)));
+      const params = new URLSearchParams(location.search);
+      const want = params.get('deck');
+      if (want) {
+        const match = decks.find(d => d.id === want.padStart(2,'0'));
+        if (match) openViewer(match);
+      }
+    })
+    .catch(() => {
+      grid.innerHTML = `<div class="soft-note">${T.no_image}</div>`;
+    });
+
+  const hint = document.getElementById('zoomHint');
+  if (hint) hint.textContent = T.zoom_hint;
+})();

--- a/styles.css
+++ b/styles.css
@@ -276,3 +276,15 @@ body[dir="rtl"] .side-menu.open{
 }
 body[dir="rtl"] .hamburger{ left:auto; right:10px; }
 /* Optional: flip overlay unchanged */
+
+.deck-thumb { aspect-ratio: 16/9; overflow: hidden; background: #fafafa; display: grid; place-items: center; }
+.deck-thumb img { width: 100%; height: 100%; object-fit: cover; } /* horizontal thumbnails */
+
+.viewer-stage img {
+  width: auto;
+  height: calc(100vh - 150px);
+  max-height: calc(100vh - 150px);
+  object-fit: contain; /* vertical full deck */
+  background: #000;
+}
+

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'cruise-dashboard-v16';
+const CACHE_NAME = 'cruise-dashboard-v17';
 
 self.addEventListener('message', (event) => {
   if (event.data?.type === 'SKIP_WAITING') self.skipWaiting();
@@ -10,7 +10,7 @@ self.addEventListener('install', (event) => {
     await cache.addAll([
       './',
       './index.html','./itinerary.html','./floor-plan.html','./important-info.html',
-      './styles.css','./app.js','./manifest.json',
+      './styles.css','./app.js','./floor.js','./manifest.json',
       './data/itinerary.json','./data/decks.json',
       './i18n/en.json','./i18n/he.json',
       './assets/images/ship.png','./assets/images/logo.png',


### PR DESCRIPTION
## Summary
- add deck list with spaced file names
- introduce floor.js with horizontal thumbnails and vertical viewer
- update styles and service worker for new floor plan assets

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0f911d24832394295be731bf6537